### PR TITLE
Add `Map` & `Set` Formats for List

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 * [Install](#install)
 * [Usage](#usage)
+  * [Formats](#formats)
 * [List](#list)
 * [References](#references)
 * [Contributors](#contributors)
@@ -66,6 +67,22 @@ if (reservedMatch)
   throw new Error(
     'User must be a domain admin to create an alias with a reserved word (see https://forwardemail.net/reserved-email-addresses).'
   );
+```
+
+### Formats
+
+The list itself comes in a few different formats. The default import is an `Array`, but also available are a `Map` and `Set` version of the list.
+
+```js
+// Array version
+const reservedEmailAddressesList = require('reserved-email-addresses-list');
+// Also available with: require('reserved-email-addresses-list/array');
+
+// Map version
+const reservedEmailAddressesMap = require('reserved-email-addresses-list/map');
+
+// set version
+const reservedEmailAddressesSet = require('reserved-email-addresses-list/set');
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ const reservedEmailAddressesList = require('reserved-email-addresses-list');
 // Map version
 const reservedEmailAddressesMap = require('reserved-email-addresses-list/map');
 
-// set version
+// Set version
 const reservedEmailAddressesSet = require('reserved-email-addresses-list/set');
 ```
 

--- a/map.cjs
+++ b/map.cjs
@@ -1,0 +1,2 @@
+const list = require('./index.json');
+module.exports = new Map(list.map((key) => [key, key]));

--- a/map.mjs
+++ b/map.mjs
@@ -1,0 +1,2 @@
+import list from './index.json';
+export default new Map(list.map((key) => ({ [key]: key })));

--- a/package.json
+++ b/package.json
@@ -35,9 +35,27 @@
   "engines": {
     "node": ">=8.3"
   },
+  "exports": {
+    ".": "./index.json",
+    "./admin-list": "./admin-list.json",
+    "./admin-list.json": "./admin-list.json",
+    "./array": "./index.json",
+    "./map": {
+      "import": "./map.mjs",
+      "require": "./map.cjs"
+    },
+    "./set": {
+      "import": "./set.mjs",
+      "require": "./set.cjs"
+    }
+  },
   "files": [
     "index.json",
-    "admin-list.json"
+    "admin-list.json",
+    "map.cjs",
+    "map.mjs",
+    "set.cjs",
+    "set.mjs"
   ],
   "homepage": "https://github.com/forwardemail/reserved-email-addresses-list",
   "husky": {
@@ -110,6 +128,14 @@
     "space": true,
     "extends": [
       "xo-lass"
+    ],
+    "overrides": [
+      {
+        "files": "*.mjs",
+        "parserOptions": {
+          "sourceType": "module"
+        }
+      }
     ]
   }
 }

--- a/set.cjs
+++ b/set.cjs
@@ -1,0 +1,2 @@
+const list = require('./index.json');
+module.exports = new Set(list);

--- a/set.mjs
+++ b/set.mjs
@@ -1,0 +1,2 @@
+import list from './index.json';
+export default new Set(list);

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,22 @@
 const test = require('ava');
 
-const list = require('..');
+const list = require('reserved-email-addresses-list');
+const array = require('reserved-email-addresses-list/array');
+const map = require('reserved-email-addresses-list/map');
+const set = require('reserved-email-addresses-list/set');
 
-test('returns an array', (t) => {
+test('default returns an array', (t) => {
   t.true(Array.isArray(list) && list.length > 0);
+});
+
+test('array returns an array', (t) => {
+  t.true(Array.isArray(array) && list.length > 0);
+});
+
+test('map returns an map', (t) => {
+  t.true(map instanceof Map && map.size > 0);
+});
+
+test('set returns an set', (t) => {
+  t.true(set instanceof Set && set.size > 0);
 });


### PR DESCRIPTION
Adding `Map` & `Set` formats for the list to give slightly more
performant variations for certain usage scenarios.

The default import is still an `Array`, but now we expose both a `/set`
and `/map` submodule that can be imported instead.

Added documentation to README about this as well

Closes #3 

Test plan:
`yarn test`